### PR TITLE
Javascript-disabled support

### DIFF
--- a/app/templates/@layout.latte
+++ b/app/templates/@layout.latte
@@ -30,6 +30,9 @@
 	<script type="text/javascript" src="{$basePath}/js/netteForms.js"></script>
 	<script type="text/javascript" src="{$basePath}/js/bootstrap.min.js"></script>
 	<script type="text/javascript" src="{$basePath}/js/highlight.min.js"></script>
+	<noscript>
+		<style> div.comment { display: block !important; } </style>
+	</noscript>
 	{block head}{/block}
 	<script type="text/javascript">
 	 var _gaq = _gaq || [];


### PR DESCRIPTION
Fitak.cz can run reasonably well with javascript disabled, except that comments are by default hidden and only get displayed through javascript. This is clearly unsatisfactory for those of us who disable javascript for security reasons - we need the comments visible by default and only hidden if javascript is enabled.
